### PR TITLE
Make CLI more aligned to IronFunctions CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,12 +30,12 @@ openstack.functions.v1 =
     fn_apps_create = picassoclient.osc.v1.apps:CreateApp
     fn_apps_delete = picassoclient.osc.v1.apps:DeleteApp
     fn_apps_update = picassoclient.osc.v1.apps:UpdateApp
-    fn_app_routes_list = picassoclient.osc.v1.routes:ListAppRoutes
-    fn_app_routes_show = picassoclient.osc.v1.routes:ShowAppRoute
-    fn_app_routes_create = picassoclient.osc.v1.routes:CreateAppRoute
-    fn_app_routes_delete = picassoclient.osc.v1.routes:DeleteAppRoute
-    fn_app_routes_update = picassoclient.osc.v1.routes:UpdateAppRoute
-    fn_app_routes_execute = picassoclient.osc.v1.routes:ExecuteAppRoute
+    fn_routes_list = picassoclient.osc.v1.routes:ListAppRoutes
+    fn_routes_show = picassoclient.osc.v1.routes:ShowAppRoute
+    fn_routes_create = picassoclient.osc.v1.routes:CreateAppRoute
+    fn_routes_delete = picassoclient.osc.v1.routes:DeleteAppRoute
+    fn_routes_update = picassoclient.osc.v1.routes:UpdateAppRoute
+    fn_routes_execute = picassoclient.osc.v1.routes:ExecuteAppRoute
 
 [global]
 setup-hooks =


### PR DESCRIPTION
This patch changes `fn-app(s)` to `fn app(s)`
```
(venv) Deniss-MacBook-Pro-2:laosclient denismakogon$ openstack --help | grep fn
  fn apps create  Creates app
  fn apps delete  Deletes app
  fn apps list   Lists apps
  fn apps show   Show app info
  fn apps update  Updates app
  fn routes create  Creates a new app route
  fn routes delete  Deletes specific app route
  fn routes execute  Runs execution against specific app route
  fn routes list  Lists app routes
  fn routes show  Shows specific route info
  fn routes update  Updates specific app route

```